### PR TITLE
Refactor: Switched Continuous Integration Test Framework from PlayWright to Jest

### DIFF
--- a/.github/workflows/code-coverage-workflow.yml
+++ b/.github/workflows/code-coverage-workflow.yml
@@ -31,7 +31,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-#          files: /coverage/**/lcov.info
+          files: /coverage/**/lcov.info
 #          flags: unittests
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/code-coverage-workflow.yml
+++ b/.github/workflows/code-coverage-workflow.yml
@@ -24,11 +24,8 @@ jobs:
       - name: Install dependencies
         run: yarn
 
-      - name: Install Playwright Browsers
-        run: npx playwright install
-
-      - name: Run tests and collect coverage
-        run: npm run test
+      - name: Run Jest Tests and Collect Coverage
+        run: npm run jest:test
 
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/code-coverage-workflow.yml` file. The change updates the workflow to run Jest tests and collect coverage instead of running Playwright tests.

* [`.github/workflows/code-coverage-workflow.yml`](diffhunk://#diff-23e85eba8160799b5cd4ef50ae09d56fd31a05673322f4e86fe76fd31f98c1b1L27-R28): Updated the workflow to run Jest tests and collect coverage. The reason for this is that the coverage of PlayWright does not decline when new code is added. It seems as if it does not recognize components but only sees the end-result (final-page).