### PR TITLE
Refactor: Updated Continuous Integration Workflow Trigger

### DIFF
--- a/.github/workflows/code-coverage-workflow.yml
+++ b/.github/workflows/code-coverage-workflow.yml
@@ -2,6 +2,8 @@ name: Continuous Integration Pipeline
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/code-coverage-workflow.yml
+++ b/.github/workflows/code-coverage-workflow.yml
@@ -1,9 +1,5 @@
 name: Continuous Integration Pipeline
-on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
+on: push
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/code-coverage-workflow.yml` file. The change modifies the event that triggers the workflow from `pull_request` to `push`.

* [`.github/workflows/code-coverage-workflow.yml`](diffhunk://#diff-23e85eba8160799b5cd4ef50ae09d56fd31a05673322f4e86fe76fd31f98c1b1L2-R2): Changed the workflow trigger from `pull_request` to `push`. This way every PR must fulfill our coverage quality gates.