### PR TITLE
Feat: Allows local Workflow Executions

### DIFF
--- a/.github/workflows/code-coverage-workflow.yml
+++ b/.github/workflows/code-coverage-workflow.yml
@@ -28,6 +28,7 @@ jobs:
         run: npm run jest:test
 
       - name: Upload Coverage to Codecov
+        if: ${{ !env.ACT }} # Do not run locally
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ node_modules/
 /playwright-coverage
 /.v8-coverage
 tests/playwright-test-artifacts
+
+
+.actrc


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/code-coverage-workflow.yml` file to add a conditional check so that the coverage upload to Codecov is skipped for local executions.

* [`.github/workflows/code-coverage-workflow.yml`](diffhunk://#diff-23e85eba8160799b5cd4ef50ae09d56fd31a05673322f4e86fe76fd31f98c1b1R29): Added a condition to the "Upload Coverage to Codecov" step to prevent it from running locally.