### PR TITLE
Tests: Improved Test Coverage by Testing useHeroIcon hook

### DIFF
--- a/tests/jest/hooks/useHeroIcon.test.tsx
+++ b/tests/jest/hooks/useHeroIcon.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it } from '@jest/globals'
+import { render } from '@testing-library/react'
+import useHeroIcon from '@/hooks/useHeroIcon'
+
+describe('useHeroIcon', () => {
+  it('renders an Icon corrrectly', async () => {
+    const Icon = useHeroIcon({ iconName: 'HomeIcon' })
+    const { container } = render(<Icon />)
+
+    const svgs = container.getElementsByTagName('svg')
+
+    expect(svgs).toHaveLength(1)
+    expect(svgs[0]).toBeInTheDocument()
+  })
+
+  it('renders an Icon with optional classes correctly', async () => {
+    const Icon = useHeroIcon({ iconName: 'HomeIcon' })
+    const { container } = render(<Icon className='size-12' />)
+
+    const svgs = container.getElementsByTagName('svg')
+
+    expect(svgs).toHaveLength(1)
+    expect(svgs[0]).toBeInTheDocument()
+    expect(svgs[0]).toHaveClass('size-12')
+  })
+})

--- a/tests/jest/hooks/useHeroIcon.test.tsx
+++ b/tests/jest/hooks/useHeroIcon.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it } from '@jest/globals'
 import { render } from '@testing-library/react'
 import useHeroIcon from '@/hooks/useHeroIcon'
+import each from 'jest-each'
 
 describe('useHeroIcon', () => {
   it('renders an Icon corrrectly', async () => {
@@ -22,5 +23,15 @@ describe('useHeroIcon', () => {
     expect(svgs).toHaveLength(1)
     expect(svgs[0]).toBeInTheDocument()
     expect(svgs[0]).toHaveClass('size-12')
+  })
+
+  each([['outline'], ['solid'], [undefined]]).it('renders an Icon with optional type correctly', async (type) => {
+    const Icon = useHeroIcon({ iconName: 'HomeIcon', type })
+    const { container } = render(<Icon />)
+
+    const svgs = container.getElementsByTagName('svg')
+
+    expect(svgs).toHaveLength(1)
+    expect(svgs[0]).toBeInTheDocument()
   })
 })

--- a/typings/icons/HeroIcons.ts
+++ b/typings/icons/HeroIcons.ts
@@ -4,5 +4,5 @@ export type HeroIconName = keyof typeof heroicons_outline
 
 export interface HeroIconProps {
   iconName: HeroIconName
-  type?: 'outline'
+  type?: 'outline' | 'solid'
 }


### PR DESCRIPTION
This pull request includes the addition of new tests for the `useHeroIcon` hook and an update to the `HeroIconProps` type definition to support a new icon type ('solid').

### Additions to tests:

* [`tests/jest/hooks/useHeroIcon.test.tsx`](diffhunk://#diff-c364dddcad2ee99b194fb09f90ac7a033883828fa48a7f97cc9efe49ad91a656R1-R37): Added tests to verify that the `useHeroIcon` hook renders icons correctly, including tests for optional classes and types.

### Type definition update:

* [`typings/icons/HeroIcons.ts`](diffhunk://#diff-5c3e8a75c227b31926586ff37cbb1fe2da92a053f5462bd23a765aba0728efcbL7-R7): Updated the `HeroIconProps` type to include the 'solid' option in the `type` property.