### PR TITLE
Feat: Continuous Delivery of Docker Images on Main Branch

### DIFF
--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -1,0 +1,37 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push-docker-image:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ${{ github.event.repository.name }}
+      REGISTRY: ghcr.io
+      IMAGE_URI: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build the Docker image
+        run: |
+          docker build -t $IMAGE_URI:latest .
+
+      - name: Push the image
+        run: |
+          docker push $IMAGE_URI:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# First Step - Install Packages in seperate step for caching purposes.
+FROM node:21-alpine AS package-installer
+WORKDIR /app
+
+COPY package.json .
+COPY yarn.lock .
+
+RUN yarn install
+
+# Second Step - Build the application
+FROM node:21-alpine AS builder
+
+WORKDIR /app
+
+COPY --from=package-installer /app/node_modules /app/node_modules
+COPY . .
+
+RUN npm run build
+
+# Final Stage: Run the Application
+FROM node:21-alpine
+
+# Set the working directory
+WORKDIR /app
+
+# Copy only the necessary build artifacts from the builder stage
+COPY --from=builder /app/.next /app/.next
+COPY --from=builder /app/public /app/public
+COPY --from=builder /app/node_modules /app/node_modules
+COPY --from=builder /app/package.json /app/package.json
+
+EXPOSE 3000
+
+# Start the Next.js application
+CMD ["npm", "run", "production"]


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building and pushing a Docker image, as well as a multi-stage `Dockerfile` for improved build efficiency and caching.

### GitHub Actions Workflow:

* [`.github/workflows/build-push-docker-image.yml`](diffhunk://#diff-16a6973e9a12990dc9265a3cf2ce7a82225ed139a55e85fb6e86e6d131afe127R1-R37): Added a new workflow to build and push a Docker image to the GitHub Container Registry on every push to the `main` branch. This includes steps for checking out the code, logging into the registry, building the Docker image, and pushing it.

### Dockerfile Enhancements:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R35): Added a multi-stage build process to improve caching and build efficiency. The first stage installs packages, the second stage builds the application, and the final stage runs the application.