### PR TITLE
Ref: Updated Build-and-Push-Docker-Image workflow and Mergify Configuration

### DIFF
--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -13,8 +13,7 @@ jobs:
   build-and-push-docker-image:
     runs-on: ubuntu-latest
     env:
-      IMAGE_NAME: ${{ github.event.repository.name }}
-      IMAGE_URI: ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+      IMAGE_URI: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -14,8 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: ${{ github.event.repository.name }}
-      REGISTRY: ghcr.io
-      IMAGE_URI: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+      IMAGE_URI: ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
 
     steps:
       - name: Checkout code
@@ -24,7 +23,7 @@ jobs:
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,8 +11,5 @@ pull_request_rules:
       merge:
         method: merge
         commit_message_template: >
-          {% if ':' in title %}
-              Merge ({{ title | regex_replace('^(.*?):.*', '\\1') | trim }}): {{ title | regex_replace('^.*?:', '') | trim }}
-          {% else %}
-              Merge: {{ title.strip() }}
-          {% endif %}
+          Merge: {{ title.strip() }}
+          


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow for building and pushing Docker images, as well as modifications to the Mergify configuration for pull request merges. The most important changes are as follows:

### Workflow improvements:

* [`.github/workflows/build-push-docker-image.yml`](diffhunk://#diff-16a6973e9a12990dc9265a3cf2ce7a82225ed139a55e85fb6e86e6d131afe127L16-R16): Simplified the environment variables by directly setting `IMAGE_URI` and `registry` values, removing intermediate variables. [[1]](diffhunk://#diff-16a6973e9a12990dc9265a3cf2ce7a82225ed139a55e85fb6e86e6d131afe127L16-R16) [[2]](diffhunk://#diff-16a6973e9a12990dc9265a3cf2ce7a82225ed139a55e85fb6e86e6d131afe127L27-R25)

### Mergify configuration:

* [`.mergify.yml`](diffhunk://#diff-6a30e47dd51449847422017b16878889b848f6602ac56d5a2e67ce8a19afade2L14-R15): Simplified the commit message template by removing conditional logic and always using a straightforward merge message format.