### PR TITLE
Feat: Implementation of the Mobile Sidebar Functionality 

### DIFF
--- a/components/root/SideBar.tsx
+++ b/components/root/SideBar.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import SideBarProps from '@/typings/root/SideBarProps'
 import { twMerge } from 'tailwind-merge'
 import { SideBarConfiguration } from '@/config/SideBarConfig'
-import { randomUUID } from 'node:crypto'
 import { RenderSideBarItem } from '@/components/root/SideBar/RenderSideBarItem'
 import DesktopSideBar from '@/components/root/SideBar/variants/DesktopSideBar'
 import MobileSideBar from '@/components/root/SideBar/variants/MobileSideBar'
@@ -25,7 +24,7 @@ export function RenderSideBarItems({ items, className }: { items: SideBarProps['
   return (
     <ul className={twMerge('pl-2 space-y-1', className)}>
       {items.map((item) => (
-        <RenderSideBarItem key={randomUUID() + item.title} {...item} />
+        <RenderSideBarItem key={item.title} {...item} />
       ))}
     </ul>
   )

--- a/components/root/SideBar.tsx
+++ b/components/root/SideBar.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import SideBarProps from '@/typings/root/SideBarProps'
-import PowerIcon from '@/icons/PowerIcon'
 import { twMerge } from 'tailwind-merge'
-import { MobileSideBarVisibilityBreakpoints, SideBarConfiguration } from '@/config/SideBarConfig'
+import { SideBarConfiguration } from '@/config/SideBarConfig'
 import { randomUUID } from 'node:crypto'
 import { RenderSideBarItem } from '@/components/root/SideBar/RenderSideBarItem'
 import DesktopSideBar from '@/components/root/SideBar/variants/DesktopSideBar'
+import MobileSideBar from '@/components/root/SideBar/variants/MobileSideBar'
 
 export default async function SideBar() {
   return (
@@ -13,19 +13,6 @@ export default async function SideBar() {
       <MobileSideBar {...SideBarConfiguration} />
       <DesktopSideBar {...SideBarConfiguration} />
     </>
-  )
-}
-
-function MobileSideBar(props: SideBarProps) {
-  return (
-    <div className={twMerge('bg-gray-50 dark:bg-neutral-900 p-4 border-b-2 justify-between', MobileSideBarVisibilityBreakpoints)}>
-      <div id={'sidebar-header'} className='flex gap-4 items-center justify-center'>
-        <PowerIcon />
-        <h3 className='text-xl'>{props.title}</h3>
-      </div>
-
-      <>Hamburger</>
-    </div>
   )
 }
 

--- a/components/root/SideBar/variants/MobileSideBar.tsx
+++ b/components/root/SideBar/variants/MobileSideBar.tsx
@@ -4,7 +4,7 @@
 import { createContext, Fragment, useContext, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { MobileSideBarVisibilityBreakpoints } from '@/config/SideBarConfig'
-import { Bars3Icon, BoltIcon, MoonIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import { BoltIcon, MoonIcon } from '@heroicons/react/24/outline'
 import SideBarProps from '@/typings/root/SideBarProps'
 import useHeroIcon from '@/hooks/useHeroIcon'
 import { Dialog, Transition } from '@headlessui/react'
@@ -60,7 +60,7 @@ function OpenCloseButton() {
   const ButtonIcon = useHeroIcon({ iconName: isOpen ? 'XMarkIcon' : 'Bars3Icon' })
 
   return (
-    <button type='button' className='-m-2.5 p-2.5 text-gray-700 dark:text-gray-200' onClick={() => setIsOpen(!isOpen)}>
+    <button name='open-close-button' type='button' className='-m-2.5 p-2.5 text-gray-700 dark:text-gray-200' onClick={() => setIsOpen(!isOpen)}>
       <span className='sr-only'>{screenReaderText}</span>
 
       <ButtonIcon className='size-6' />

--- a/components/root/SideBar/variants/MobileSideBar.tsx
+++ b/components/root/SideBar/variants/MobileSideBar.tsx
@@ -4,10 +4,11 @@
 import { createContext, Fragment, useContext, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { MobileSideBarVisibilityBreakpoints } from '@/config/SideBarConfig'
-import { Bars3Icon, MoonIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import { Bars3Icon, BoltIcon, MoonIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import SideBarProps from '@/typings/root/SideBarProps'
 import useHeroIcon from '@/hooks/useHeroIcon'
 import { Dialog, Transition } from '@headlessui/react'
+import { RenderSideBarItems } from '@/components/root/SideBar'
 
 interface MobileSideBarContextProps {
   isOpen: boolean
@@ -32,6 +33,20 @@ export default function MobileSideBar(props: SideBarProps) {
         <span className='flex-1 text-center text-lg font-semibold leading-6 text-gray-700 dark:text-gray-200'>{props.title}</span>
         <MoonIcon className='size-6' />
       </div>
+
+      <MobileSideBarDialog>
+        <div className='flex grow flex-col gap-y-5 overflow-y-auto bg-white pb-2 dark:bg-neutral-800'>
+          <div className='flex shrink-0 items-center justify-between border-b-2 pl-4 py-4 border-solid px-2 border-gray-400 dark:border-gray-200 dark:bg-neutral-900'>
+            <BoltIcon className='size-6' />
+            <span className='text-lg flex-1 mx-auto pr-4 text-center font-semibold leading-6 text-gray-700 dark:text-gray-200'>Navigation</span>
+            <OpenCloseButton />
+          </div>
+
+          <nav className='flex flex-1 flex-col pr-4 pl-2'>
+            <RenderSideBarItems items={props.items} />
+          </nav>
+        </div>
+      </MobileSideBarDialog>
     </MobileSideBarContext.Provider>
   )
 }

--- a/components/root/SideBar/variants/MobileSideBar.tsx
+++ b/components/root/SideBar/variants/MobileSideBar.tsx
@@ -30,7 +30,7 @@ export default function MobileSideBar(props: SideBarProps) {
     <MobileSideBarContext.Provider value={{ isOpen, setIsOpen }}>
       <div id='mobile-sidebar-top-bar' className={twMerge('bg-gray-50 dark:bg-neutral-900 p-4 border-b-2 justify-between', MobileSideBarVisibilityBreakpoints)}>
         <OpenCloseButton />
-        <span className='flex-1 text-center text-lg font-semibold leading-6 text-gray-700 dark:text-gray-200'>{props.title}</span>
+        <h3 className='flex-1 text-center text-lg font-semibold leading-6 text-gray-700 dark:text-gray-200'>{props.title}</h3>
         <MoonIcon className='size-6' />
       </div>
 

--- a/components/root/SideBar/variants/MobileSideBar.tsx
+++ b/components/root/SideBar/variants/MobileSideBar.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { createContext, useContext, useState } from 'react'
+import { twMerge } from 'tailwind-merge'
+import { MobileSideBarVisibilityBreakpoints } from '@/config/SideBarConfig'
+import { Bars3Icon, MoonIcon } from '@heroicons/react/24/outline'
+import SideBarProps from '@/typings/root/SideBarProps'
+
+interface MobileSideBarContextProps {
+  isOpen: boolean
+  setIsOpen: (value: boolean) => void
+}
+
+const MobileSideBarContext = createContext<MobileSideBarContextProps>({} as MobileSideBarContextProps)
+
+export function useMobileSideBarContext() {
+  const context = useContext(MobileSideBarContext)
+
+  return context
+}
+
+export default function MobileSideBar(props: SideBarProps) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <MobileSideBarContext.Provider value={{ isOpen, setIsOpen }}>
+      <div id='mobile-sidebar-top-bar' className={twMerge('bg-gray-50 dark:bg-neutral-900 p-4 border-b-2 justify-between', MobileSideBarVisibilityBreakpoints)}>
+        <OpenSideBarButton />
+        <span className='flex-1 text-center text-lg font-semibold leading-6 text-gray-700 dark:text-gray-200'>{props.title}</span>
+        <MoonIcon className='size-6' />
+      </div>
+    </MobileSideBarContext.Provider>
+  )
+}
+
+function OpenSideBarButton() {
+  const { setIsOpen } = useMobileSideBarContext()
+
+  return (
+    <button type='button' className='-m-2.5 p-2.5 text-gray-700 dark:text-gray-200 lg:hidden' onClick={() => setIsOpen(true)}>
+      <span className='sr-only'>Open sidebar</span>
+      <Bars3Icon className='size-6' aria-hidden='true' />
+    </button>
+  )
+}

--- a/components/root/SideBar/variants/MobileSideBar.tsx
+++ b/components/root/SideBar/variants/MobileSideBar.tsx
@@ -60,7 +60,7 @@ function OpenCloseButton() {
   const ButtonIcon = useHeroIcon({ iconName: isOpen ? 'XMarkIcon' : 'Bars3Icon' })
 
   return (
-    <button type='button' className='-m-2.5 p-2.5 text-gray-700 dark:text-gray-200 lg:hidden' onClick={() => setIsOpen(!isOpen)}>
+    <button type='button' className='-m-2.5 p-2.5 text-gray-700 dark:text-gray-200' onClick={() => setIsOpen(!isOpen)}>
       <span className='sr-only'>{screenReaderText}</span>
 
       <ButtonIcon className='size-6' />
@@ -77,7 +77,7 @@ function MobileSideBarDialog({ children }: { children: React.ReactNode }) {
 
   return (
     <Transition.Root show={isOpen} as={Fragment}>
-      <Dialog as='div' className='relative z-50 lg:hidden' onClose={setIsOpen}>
+      <Dialog as='div' className={twMerge('relative z-50', MobileSideBarVisibilityBreakpoints)} onClose={setIsOpen}>
         <Transition.Child
           as={Fragment}
           enter='transition-opacity ease-linear duration-300'

--- a/components/root/SideBar/variants/MobileSideBar.tsx
+++ b/components/root/SideBar/variants/MobileSideBar.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable react/jsx-max-depth */
 'use client'
 
-import { createContext, useContext, useState } from 'react'
+import { createContext, Fragment, useContext, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { MobileSideBarVisibilityBreakpoints } from '@/config/SideBarConfig'
 import { Bars3Icon, MoonIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import SideBarProps from '@/typings/root/SideBarProps'
 import useHeroIcon from '@/hooks/useHeroIcon'
+import { Dialog, Transition } from '@headlessui/react'
 
 interface MobileSideBarContextProps {
   isOpen: boolean
@@ -49,5 +50,43 @@ function OpenCloseButton() {
 
       <ButtonIcon className='size-6' />
     </button>
+  )
+}
+
+/**
+ * Renders the dialog that slides in from the left and displays renders the provided children in it
+ * @param children The content / children that are rendered in the dialog
+ */
+function MobileSideBarDialog({ children }: { children: React.ReactNode }) {
+  const { isOpen, setIsOpen } = useMobileSideBarContext()
+
+  return (
+    <Transition.Root show={isOpen} as={Fragment}>
+      <Dialog as='div' className='relative z-50 lg:hidden' onClose={setIsOpen}>
+        <Transition.Child
+          as={Fragment}
+          enter='transition-opacity ease-linear duration-300'
+          enterFrom='opacity-0'
+          enterTo='opacity-100'
+          leave='transition-opacity ease-linear duration-300'
+          leaveFrom='opacity-100'
+          leaveTo='opacity-0'>
+          <div className='fixed inset-0 bg-neutral-900/80' />
+        </Transition.Child>
+
+        <div className='fixed inset-0 flex'>
+          <Transition.Child
+            as={Fragment}
+            enter='transition ease-in-out duration-300 transform'
+            enterFrom='-translate-x-full'
+            enterTo='translate-x-0'
+            leave='transition ease-in-out duration-300 transform'
+            leaveFrom='translate-x-0'
+            leaveTo='-translate-x-full'>
+            <Dialog.Panel className='relative flex w-full max-w-xs flex-1 sm:max-w-sm'>{children}</Dialog.Panel>
+          </Transition.Child>
+        </div>
+      </Dialog>
+    </Transition.Root>
   )
 }

--- a/components/root/SideBar/variants/MobileSideBar.tsx
+++ b/components/root/SideBar/variants/MobileSideBar.tsx
@@ -17,7 +17,7 @@ interface MobileSideBarContextProps {
 
 const MobileSideBarContext = createContext<MobileSideBarContextProps>({} as MobileSideBarContextProps)
 
-export function useMobileSideBarContext() {
+function useMobileSideBarContext() {
   const context = useContext(MobileSideBarContext)
 
   return context

--- a/components/root/SideBar/variants/MobileSideBar.tsx
+++ b/components/root/SideBar/variants/MobileSideBar.tsx
@@ -1,10 +1,12 @@
+/* eslint-disable react/jsx-max-depth */
 'use client'
 
 import { createContext, useContext, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { MobileSideBarVisibilityBreakpoints } from '@/config/SideBarConfig'
-import { Bars3Icon, MoonIcon } from '@heroicons/react/24/outline'
+import { Bars3Icon, MoonIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import SideBarProps from '@/typings/root/SideBarProps'
+import useHeroIcon from '@/hooks/useHeroIcon'
 
 interface MobileSideBarContextProps {
   isOpen: boolean
@@ -25,7 +27,7 @@ export default function MobileSideBar(props: SideBarProps) {
   return (
     <MobileSideBarContext.Provider value={{ isOpen, setIsOpen }}>
       <div id='mobile-sidebar-top-bar' className={twMerge('bg-gray-50 dark:bg-neutral-900 p-4 border-b-2 justify-between', MobileSideBarVisibilityBreakpoints)}>
-        <OpenSideBarButton />
+        <OpenCloseButton />
         <span className='flex-1 text-center text-lg font-semibold leading-6 text-gray-700 dark:text-gray-200'>{props.title}</span>
         <MoonIcon className='size-6' />
       </div>
@@ -33,13 +35,19 @@ export default function MobileSideBar(props: SideBarProps) {
   )
 }
 
-function OpenSideBarButton() {
-  const { setIsOpen } = useMobileSideBarContext()
+/**
+ * This component renders a button that opens or closes the mobile sidebar depending on its open-state.
+ */
+function OpenCloseButton() {
+  const { isOpen, setIsOpen } = useMobileSideBarContext()
+  const screenReaderText = isOpen ? 'Close sidebar' : 'Open sidebar'
+  const ButtonIcon = useHeroIcon({ iconName: isOpen ? 'XMarkIcon' : 'Bars3Icon' })
 
   return (
-    <button type='button' className='-m-2.5 p-2.5 text-gray-700 dark:text-gray-200 lg:hidden' onClick={() => setIsOpen(true)}>
-      <span className='sr-only'>Open sidebar</span>
-      <Bars3Icon className='size-6' aria-hidden='true' />
+    <button type='button' className='-m-2.5 p-2.5 text-gray-700 dark:text-gray-200 lg:hidden' onClick={() => setIsOpen(!isOpen)}>
+      <span className='sr-only'>{screenReaderText}</span>
+
+      <ButtonIcon className='size-6' />
     </button>
   )
 }

--- a/tests/jest/root/MobileSideBar.test.tsx
+++ b/tests/jest/root/MobileSideBar.test.tsx
@@ -1,16 +1,15 @@
-import { act, render, screen } from '@testing-library/react'
+import { act, render, renderHook, screen } from '@testing-library/react'
 import { describe, it } from '@jest/globals'
 import { SideBarConfiguration } from '@/config/SideBarConfig'
 import { wait } from '@testing-library/user-event/dist/utils'
-import { mockAnimationsApi } from 'jsdom-testing-mocks'
 import MobileSideBar from '@/components/root/SideBar/variants/MobileSideBar'
+import { mockAnimationsApi } from 'jsdom-testing-mocks'
 
 mockAnimationsApi()
 
 describe('MobileSideBar', () => {
   it('has the correct title', async () => {
-    const Component = await MobileSideBar({ ...SideBarConfiguration })
-    render(Component)
+    renderHook(() => render(MobileSideBar({ ...SideBarConfiguration })))
 
     const sidebarHeading = screen.getByRole('heading', { level: 3 })
 
@@ -19,8 +18,7 @@ describe('MobileSideBar', () => {
   })
 
   it('shows navigation items and containers (=item with subitems)', async () => {
-    const Component = await MobileSideBar({ ...SideBarConfiguration })
-    render(Component)
+    renderHook(() => render(MobileSideBar({ ...SideBarConfiguration })))
 
     //? Open Dialog
     const openCloseButton = screen.getByRole('button', { name: 'open-close-button' })

--- a/tests/jest/root/MobileSideBar.test.tsx
+++ b/tests/jest/root/MobileSideBar.test.tsx
@@ -21,8 +21,8 @@ describe('MobileSideBar', () => {
     renderHook(() => render(MobileSideBar({ ...SideBarConfiguration })))
 
     //? Open Dialog
-    const openCloseButton = screen.getByRole('button', { name: 'open-close-button' })
-    openCloseButton.click()
+    const openCloseButton = screen.getByRole('button', { name: 'Open sidebar' })
+    act(() => openCloseButton.click())
 
     // Todo DRY: Extract this into a helper function
     const initialSidebarItems = screen.getAllByRole('listitem', {})

--- a/tests/jest/root/MobileSideBar.test.tsx
+++ b/tests/jest/root/MobileSideBar.test.tsx
@@ -1,0 +1,60 @@
+import { act, render, screen } from '@testing-library/react'
+import { describe, it } from '@jest/globals'
+import { SideBarConfiguration } from '@/config/SideBarConfig'
+import { wait } from '@testing-library/user-event/dist/utils'
+import { mockAnimationsApi } from 'jsdom-testing-mocks'
+import MobileSideBar from '@/components/root/SideBar/variants/MobileSideBar'
+
+mockAnimationsApi()
+
+describe('MobileSideBar', () => {
+  it('has the correct title', async () => {
+    const Component = await MobileSideBar({ ...SideBarConfiguration })
+    render(Component)
+
+    const sidebarHeading = screen.getByRole('heading', { level: 3 })
+
+    expect(sidebarHeading).toBeInTheDocument()
+    expect(sidebarHeading).toHaveTextContent(SideBarConfiguration.title)
+  })
+
+  it('shows navigation items and containers (=item with subitems)', async () => {
+    const Component = await MobileSideBar({ ...SideBarConfiguration })
+    render(Component)
+
+    //? Open Dialog
+    const openCloseButton = screen.getByRole('button', { name: 'open-close-button' })
+    openCloseButton.click()
+
+    // Todo DRY: Extract this into a helper function
+    const initialSidebarItems = screen.getAllByRole('listitem', {})
+    await act(() => openSideBarElementDisclosures(initialSidebarItems))
+
+    //* After opening all disclosures, all items should be visible
+    const items = screen.getAllByRole('listitem', {})
+    const itemTitles = items.map((item) => item.getElementsByClassName('element-title')[0].textContent)
+
+    const expectedItems = SideBarConfiguration.items.reduce((acc, item) => (item.items ? acc.concat(item).concat(item.items) : acc.concat(item)), [])
+
+    expect(items).toHaveLength(expectedItems.length)
+    expect(itemTitles).toEqual(expectedItems.map((item) => item.title))
+  })
+})
+
+/**
+ * Opens all disclosures in the sidebar recursively.
+ * @returns Promise<void> - opens all disclosures by using the act function
+ * @param elements
+ */
+async function openSideBarElementDisclosures(elements: HTMLElement[]) {
+  for (const element of elements) {
+    //* Disclosure-Open button
+    if (element.children[0].tagName === 'BUTTON') {
+      const button = element.children[0] as HTMLButtonElement
+
+      //? Open Disclosure-Panels (recursively due to the act function)
+      button.click()
+      await wait(500) // wait for animation to finish
+    }
+  }
+}


### PR DESCRIPTION
This pull request includes significant changes to the `SideBar` component, mainly focusing on the restructuring of the `MobileSideBar` implementation and its associated tests. The most important changes include moving the `MobileSideBar` to a separate file, the rendering of SideBarItems by using the `RenderSideBarItems` component, and adding tests for the `MobileSideBar`.

Restructuring and refactoring:

* [`components/root/SideBar.tsx`](diffhunk://#diff-53925fa4a7903f8027d527967e8d38ee7c478a09a9c59e8870962bec86a9dc14L3-R7): Removed the inline `MobileSideBar` component and its dependencies, and imported the new `MobileSideBar` from a separate file. [[1]](diffhunk://#diff-53925fa4a7903f8027d527967e8d38ee7c478a09a9c59e8870962bec86a9dc14L3-R7) [[2]](diffhunk://#diff-53925fa4a7903f8027d527967e8d38ee7c478a09a9c59e8870962bec86a9dc14L19-L31)

* [`components/root/SideBar.tsx`](diffhunk://#diff-53925fa4a7903f8027d527967e8d38ee7c478a09a9c59e8870962bec86a9dc14L41-R27): Refactored the key generation for `RenderSideBarItems` to use `item.title` instead of `randomUUID() + item.title`.

New `MobileSideBar` implementation:

* [`components/root/SideBar/variants/MobileSideBar.tsx`](diffhunk://#diff-e0f29134d15c926eab554a71a7cfc3f4b42a397bf67dc88c0713ab000936d9ccR1-R107): Added a new file for the `MobileSideBar` component, implementing context for managing open/close state, and using `Dialog`, `Transition` from `@headlessui/react` for animations and rendering of its SideBarItems

Testing:

* [`tests/jest/root/MobileSideBar.test.tsx`](diffhunk://#diff-9d789fead184c1c14aa3de0f71131dad9efcc524eae05334f52b399af40efc60R1-R58): Added new tests for the `MobileSideBar` component to verify the title and the correct rendering of navigation items and containers, based on #30.