### PR TITLE
Bug: Jest - Testing Client Components with useState fail

### DIFF
--- a/components/ClientComponent.tsx
+++ b/components/ClientComponent.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import { useState } from 'react'
+
+export default function ClientComponent() {
+  const [mode, setMode] = useState(false)
+
+  return <h1>This is a client component...</h1>
+}

--- a/tests/jest/root/ClientComponent.test.tsx
+++ b/tests/jest/root/ClientComponent.test.tsx
@@ -1,0 +1,11 @@
+import { it } from '@jest/globals'
+import { render, screen } from '@testing-library/react'
+import ClientComponent from '@/components/ClientComponent'
+
+it('test client component', async () => {
+  const Component = await ClientComponent()
+  render(Component)
+
+  const heading = screen.getByRole('heading', { level: 1 })
+  expect(heading).toBeInTheDocument()
+})


### PR DESCRIPTION
This pull request introduces a new client-side component and its corresponding test. The most important changes include the creation of the `ClientComponent` and the addition of a Jest test to ensure the component renders correctly.

New client-side component:

* [`components/ClientComponent.tsx`](diffhunk://#diff-7be456210c231423ae02cebd77814befc3969d236f1e2ebb1b2337e260000c69R1-R9): Added a new client-side component that uses the `useState` hook to manage a `mode` state and renders a heading element.

Testing:

* [`tests/jest/root/ClientComponent.test.tsx`](diffhunk://#diff-8d7fa086c329f563836899e09f258439e1885c72dc9a0986dd0b5f77c516cd52R1-R11): Added a Jest test that imports and renders the `ClientComponent`, then verifies that the heading element is present in the document.