### PR TITLE
Tests: Added Test Case to check whether the correct SideBar variant is rendered

### DIFF
--- a/components/root/SideBar/variants/DesktopSideBar.tsx
+++ b/components/root/SideBar/variants/DesktopSideBar.tsx
@@ -8,7 +8,7 @@ import Link from 'next/link'
 
 export default function DesktopSideBar(props: SideBarProps) {
   return (
-    <div className={twMerge('fixed dark:bg-neutral-900/50 bg-gray-200 h-full flex-col p-3 pl-2', DesktopSideBarVisibilityBreakpoints)}>
+    <div id='desktop-sidebar-container' className={twMerge('fixed dark:bg-neutral-900/50 bg-gray-200 h-full flex-col p-3 pl-2', DesktopSideBarVisibilityBreakpoints)}>
       <div id={'sidebar-header'} className='flex gap-4 items-center justify-center pb-3 border-b-2 dark:border-neutral-300 border-gray-600'>
         <PowerIcon />
         <h3 className='text-xl dark:text-gray-300 text-gray-700'>{props.title}</h3>

--- a/tests/jest/root/SideBar.test.tsx
+++ b/tests/jest/root/SideBar.test.tsx
@@ -1,0 +1,39 @@
+import { describe } from '@jest/globals'
+import { configure, fireEvent, render, waitFor } from '@testing-library/react'
+import SideBar from '@/components/root/SideBar'
+import each from 'jest-each'
+
+configure({
+  computedStyleSupportsPseudoElements: true,
+})
+
+describe('SideBar', () => {
+  /**
+   * Test whether the SideBar renders the correct version depending on the screen-size
+   */
+  each([
+    [1920, 1080, 'desktop-sidebar-container'],
+    [606, 812, 'mobile-sidebar-top-bar'],
+  ]).it('renders the correct SideBar version depending on screen-size', async (width, height, containerId) => {
+    const Component = await SideBar()
+    const { container } = render(Component)
+
+    //? Note that the concept of resizing the windows is valid, Jest does not load and fully parse CSS files.
+    //? Therefore, it does not truly know whether an element is visible or not at certain breakpoints.
+    await waitFor(() => {
+      global.innerWidth = width
+
+      console.log(global.innerWidth)
+      fireEvent(global, new Event('resize'))
+      global.dispatchEvent(new Event('resize'))
+    })
+
+    const sidebarContainer = container.querySelector(`#${containerId}`)
+
+    expect(sidebarContainer).toBeInTheDocument()
+    expect(sidebarContainer).toBeVisible()
+
+    const displayProperty = getComputedStyle(sidebarContainer as Element).getPropertyValue('display')
+    expect(displayProperty).not.toBe('none')
+  })
+})


### PR DESCRIPTION
This pull request includes changes to the `DesktopSideBar` component by adding an id and one test to check whether the correct SideBar version is rendered based on screen size.

### Component Enhancements:

* [`components/root/SideBar/variants/DesktopSideBar.tsx`](diffhunk://#diff-06baa93247fb9a0d6f31bd5debaa134ac42ef62cef6de6dee64f0a3258aa7838L11-R11): Added an `id` attribute to the main container `div` to uniquely identify the desktop sidebar container.

### Testing Improvements:

* [`tests/jest/root/SideBar.test.tsx`](diffhunk://#diff-ade4ed3e0b53ccb6ffd8f08d59527deef7939543dc129fe83fb296d62b6ce65eR1-R39): Added a new test suite using `jest-each` to verify that the `SideBar` component renders the correct version (desktop or mobile) based on screen size. This includes configuring the test environment to support pseudo-elements and simulating window resize events.