### PR TITLE
Fix: Added Content Permissions write to Semantic Versioning workflow

### DIFF
--- a/.github/workflows/semantic-versioning.yml
+++ b/.github/workflows/semantic-versioning.yml
@@ -4,6 +4,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 env:
   GH_TOKEN: ${{ secrets.ACCESS_TOKEN_SEMANTIC_VERSIONING }}
 

--- a/.github/workflows/semantic-versioning.yml
+++ b/.github/workflows/semantic-versioning.yml
@@ -1,3 +1,5 @@
+name: Automatic Semantic Versioning
+
 on:
   push:
     branches:
@@ -11,7 +13,7 @@ env:
   GH_TOKEN: ${{ secrets.ACCESS_TOKEN_SEMANTIC_VERSIONING }}
 
 jobs:
-  versioning:
+  semantic-versioning:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/semantic-versioning.yml` file to fix the workflow execution failure for automatic semantic versioning.

Workflow enhancements:

* Added a name to the workflow: `Automatic Semantic Versioning`.
* Changed the job name from `versioning` to `semantic-versioning` for better clarity.
* Added permissions for `contents: write` to ensure the workflow has the necessary access.