### PR TITLE
Fix: Removed `@semantic-release/npm` Plugin from Semantic Versioning Configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
       "@semantic-release/github",
-      "@semantic-release/npm",
       [
         "@semantic-release/git",
         {


### PR DESCRIPTION
This pull request includes a minor change to the `package.json` file. The change removes the `@semantic-release/npm` package from the list of dependencies.

Dependency management:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L95): Removed the `@semantic-release/npm` package from the list of dependencies, as it requires an 2FA npm token. 