### PR TITLE
Fix: Automatic Merge Behavior and Manual-Merge Classification

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,7 +8,7 @@ pull_request_rules:
       - approved-reviews-by>=1
       - check-success=codecov/patch
       - check-success=codecov/project
-      - label != manual-merge
+      - -approved-reviews-by=harvey-specter # require manual-merge when auto-approved
     actions:
       merge:
         method: merge
@@ -19,7 +19,7 @@ pull_request_rules:
 
   - name: Manual merge when Auto-Reviewed
     conditions:
-      - status-success=auto-review
+      - approved-reviews-by=harvey-specter
     actions:
       label:
         add:


### PR DESCRIPTION
This pull request includes changes to the `pull_request_rules` in the `.mergify.yml` file to improve the handling of auto-approved pull requests. The most important changes are:

* Modified the condition to require manual merging when a pull request is auto-approved by Harvey Specter.
* Updated the condition for manual merge to check for approval by Harvey Specter instead of the status success of auto-review.