### PR TITLE
Fix: Resolved incorrect Auto-Reviewer Name and Continous Assignment of same Reviewer

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -37,6 +37,7 @@ pull_request_rules:
       - check-success=codecov/project
       - -approved-reviews-by=Harvey-Reginald-Specter
       - -author=Marty-Byrde
+      - -review-requested=Marty-Byrde # has not been requested for review
     actions:
       request_reviews:
         users:
@@ -54,6 +55,7 @@ pull_request_rules:
       - check-success=codecov/project
       - -approved-reviews-by=Harvey-Reginald-Specter
       - -author=MrsicMarko
+      - -review-requested=MrsicMarko # has not been requested for review
     actions:
       request_reviews:
         users:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,7 +8,7 @@ pull_request_rules:
       - approved-reviews-by>=1
       - check-success=codecov/patch
       - check-success=codecov/project
-      - -approved-reviews-by=harvey-specter # require manual-merge when auto-approved
+      - -approved-reviews-by=Harvey-Reginald-Specter # require manual-merge when auto-approved
     actions:
       merge:
         method: merge
@@ -19,7 +19,7 @@ pull_request_rules:
 
   - name: Manual merge when Auto-Reviewed
     conditions:
-      - approved-reviews-by=harvey-specter
+      - approved-reviews-by=Harvey-Reginald-Specter
     actions:
       label:
         add:
@@ -35,7 +35,7 @@ pull_request_rules:
       - -approved-reviews-by>=1
       - check-success=codecov/patch
       - check-success=codecov/project
-      - -approved-reviews-by=harvey-specter
+      - -approved-reviews-by=Harvey-Reginald-Specter
       - -author=Marty-Byrde
     actions:
       request_reviews:
@@ -52,7 +52,7 @@ pull_request_rules:
       - -approved-reviews-by>=1
       - check-success=codecov/patch
       - check-success=codecov/project
-      - -approved-reviews-by=harvey-specter
+      - -approved-reviews-by=Harvey-Reginald-Specter
       - -author=MrsicMarko
     actions:
       request_reviews:


### PR DESCRIPTION
This pull request includes changes to the `.mergify.yml` file, specifically modifying the `pull_request_rules` to update the (auto-)reviewer name and add conditions for review requests.

Updates to reviewer name and review conditions:

* [`.mergify.yml`](diffhunk://#diff-6a30e47dd51449847422017b16878889b848f6602ac56d5a2e67ce8a19afade2L11-R11): Changed `approved-reviews-by` from `harvey-specter` to `Harvey-Reginald-Specter` in multiple conditions to reflect the correct reviewer name. [[1]](diffhunk://#diff-6a30e47dd51449847422017b16878889b848f6602ac56d5a2e67ce8a19afade2L11-R11) [[2]](diffhunk://#diff-6a30e47dd51449847422017b16878889b848f6602ac56d5a2e67ce8a19afade2L22-R22) [[3]](diffhunk://#diff-6a30e47dd51449847422017b16878889b848f6602ac56d5a2e67ce8a19afade2L38-R40) [[4]](diffhunk://#diff-6a30e47dd51449847422017b16878889b848f6602ac56d5a2e67ce8a19afade2L55-R58)
* [`.mergify.yml`](diffhunk://#diff-6a30e47dd51449847422017b16878889b848f6602ac56d5a2e67ce8a19afade2L38-R40): Added conditions to check if review has not been requested for specific users (`Marty-Byrde` and `MrsicMarko`). This means that Mergify will not try to request a review from the same person a second time if it was already requested. [[1]](diffhunk://#diff-6a30e47dd51449847422017b16878889b848f6602ac56d5a2e67ce8a19afade2L38-R40) [[2]](diffhunk://#diff-6a30e47dd51449847422017b16878889b848f6602ac56d5a2e67ce8a19afade2L55-R58)