### PR TITLE
Fix: Resolved Semantic Versioning Release Error

### DIFF
--- a/.pr-bot.json
+++ b/.pr-bot.json
@@ -2,7 +2,7 @@
   "approvalRules": [
     {
       "changedFiles": {
-        "allowed": [".github/*", "yarn.lock", ".pr-bot.json", ".mergify.yml", "codecov.yml", ".commitlintrc.json", ".husky/*", ".actrc"]
+        "allowed": [".github/*", "yarn.lock", ".pr-bot.json", ".mergify.yml", "codecov.yml", ".commitlintrc.json", ".husky/*", ".actrc", ".releaserc.json"]
       }
     }
   ]

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "conventional-changelog-conventionalcommits": "^8.0.0",
     "eslint": "8.57.0",
     "eslint-config-next": "15.0.3",
     "eslint-config-prettier": "^9.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5141,6 +5141,13 @@ conventional-changelog-conventionalcommits@^7.0.2:
   dependencies:
     compare-func "^2.0.0"
 
+conventional-changelog-conventionalcommits@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz#3fa2857c878701e7f0329db5a1257cb218f166fe"
+  integrity sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==
+  dependencies:
+    compare-func "^2.0.0"
+
 conventional-changelog-writer@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-8.0.0.tgz#81522ed40400a4ca8ab78a42794aae9667c745ae"


### PR DESCRIPTION
This pull request includes updates the `package.json` by installing a new packaged needed for the semantic-versioning. Also the `.releaserc` config file has been added to the auto-approve list.


### Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R58): Added `conventional-changelog-conventionalcommits` version `^8.0.0` as a new dependency.

### Changes to approval rules:

* [`.pr-bot.json`](diffhunk://#diff-0f699da466d3b43dfa43d2920a2df76e9684fc9ffcd795c7eb8d56e577e9542bL5-R5): Added `.releaserc.json` to the list of allowed changed files.
