### PR TITLE
CI: Updated Mergify Configuration to Stop Auto Merging when labeled Manual Merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,6 +8,7 @@ pull_request_rules:
       - approved-reviews-by>=1
       - check-success=codecov/patch
       - check-success=codecov/project
+      - -label=manual-merge # do not auto merge when manual-merge label is present
       - -approved-reviews-by=Harvey-Reginald-Specter # require manual-merge when auto-approved
     actions:
       merge:


### PR DESCRIPTION
This pull request includes a small change to the `.mergify.yml` file. The change ensures that the auto-merge process is halted when the `manual-merge` label is present.

### Changes to `.mergify.yml`:

* Added a condition to prevent auto-merge when the `manual-merge` label is present.
