### PR TITLE
CI: Adjusted Mergify Configuration to Uphold Merging / Release Strategies

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -81,12 +81,13 @@ pull_request_rules:
       - -approved-reviews-by=Harvey-Reginald-Specter
       - -author=Marty-Byrde
       - -review-requested=Marty-Byrde # has not been requested for review
+      - base=canary
     actions:
       request_reviews:
         users:
           - "Marty-Byrde"
       comment:
-        message: "Auto-Assigned Marty-Byrde as Reviewer to this Pull Request."
+        message: "Auto-Assigned Marty-Byrde as a Reviewer to this Pull Request."
 
   - name: Auto-Assign MrsicMarko as Reviewer when Status Checks Pass and MrsicMarko is not the Author
     conditions:
@@ -99,12 +100,13 @@ pull_request_rules:
       - -approved-reviews-by=Harvey-Reginald-Specter
       - -author=MrsicMarko
       - -review-requested=MrsicMarko # has not been requested for review
+      - base=canary
     actions:
       request_reviews:
         users:
           - "MrsicMarko"
       comment:
-        message: "Auto-Assigned MrsicMarko as Reviewer to this Pull Request."
+        message: "Auto-Assigned MrsicMarko as a Reviewer to this Pull Request."
 
   - name: Auto-Assign Pull request author to Pull request
     conditions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,8 +7,8 @@ pull_request_rules:
       comment:
         message: "@{{ author }} The base of the Pull request cannot be set to `main`. Please use `canary` instead."
 
-  - name: Automatic merge
-    description: Merge when PR passes all status checks and has been reviewed
+  - name: Automatically Merge Pull Requests into Canary
+    description: Merges a PR once all status-checks pass and once it has been reviewed by at least one person
     conditions:
       - status-success=evaluate-code-coverage
       - status-success=run-all-tests
@@ -18,13 +18,15 @@ pull_request_rules:
       - check-success=codecov/project
       - -label=manual-merge # do not auto merge when manual-merge label is present
       - -approved-reviews-by=Harvey-Reginald-Specter # require manual-merge when auto-approved
+      - base=canary
     actions:
+      comment:
+        message: This Pull request satisfies all status-checks and will be automatically merged soon.
       merge:
         method: merge
         commit_message_template: >
           Merge: {{ title.strip() }}
-      comment:
-        message: This Pull request satisfies all status-checks and will be automatically merged soon.
+      
 
   - name: Add 'Manual-Merge' label to PR when Auto-Reviewed
     conditions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -43,6 +43,22 @@ pull_request_rules:
       merge:
         method: rebase
 
+  - name: Notify about Missing Done Label
+    description: A Pull Request that is to be merged into the main branch must be marked as done to be merged. Notify authors about missing label, when all checks pass.
+    conditions:
+      - status-success=evaluate-code-coverage
+      - status-success=run-all-tests
+      - status-success=build-nextjs-application
+      - check-success=codecov/patch
+      - check-success=codecov/project
+      - -label=done
+      - base=main
+      - head=canary
+    actions:
+      comment:
+        message: Keep in mind, that this Pull request is only merged once it is marked as done!
+
+
   - name: Add 'Manual-Merge' label to PR when Auto-Reviewed
     conditions:
       - approved-reviews-by=Harvey-Reginald-Specter

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -26,7 +26,22 @@ pull_request_rules:
         method: merge
         commit_message_template: >
           Merge: {{ title.strip() }}
-      
+
+  - name: Automatically Merge Pull Requests from Canary into Main
+    description: Merges Changes from Canary into Main once all status checks have passed and marked as done
+    conditions:
+      - status-success=evaluate-code-coverage
+      - status-success=run-all-tests
+      - status-success=build-nextjs-application
+      - check-success=codecov/patch
+      - check-success=codecov/project
+      - label=done # only merge once marked as done
+      - base=main
+    actions:
+      comment:
+        message: This Pull request satisfies all status-checks and will be automatically merged soon.
+      merge:
+        method: rebase
 
   - name: Add 'Manual-Merge' label to PR when Auto-Reviewed
     conditions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -116,9 +116,9 @@ pull_request_rules:
         add_users:
           - "{{ author }}"
 
-  - name: Automatic Update-Branch when Main is ahead
+  - name: Automatic Update-Branch when Canary is ahead
     conditions:
-      - base = main
+      - base = canary
       - "#commits-behind > 0"
     actions:
       update:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,4 +1,12 @@
 pull_request_rules:
+  - name: Wrong Pull Request Base
+    conditions:
+      - base=main
+      - -head=canary
+    actions:
+      comment:
+        message: "@{{ author }} The base of the Pull request cannot be set to `main`. Please use `canary` instead."
+
   - name: Automatic merge
     description: Merge when PR passes all status checks and has been reviewed
     conditions:


### PR DESCRIPTION
This pull request includes significant changes to the `.mergify.yml` configuration file, primarily focusing on automating the merging process and improving the workflow for pull requests. The most important changes involve adding new rules for handling different pull request bases and updating existing rules to reflect the new branching strategy.

---
### Updated Merge / Release Strategies
New changes are to be merged into the canary branch. These changes must pass all the status-checks and must be reviewed so that they can be merged. Once all checks pass PR's will be merged automatically, unless they are marked as `manual-merge`. 

New changes are only merged into `main` branch via Pull requests from the `canary` branch. This means that changes must first be merged into the canary branch, as mentioned above, so that they can be merged into the main branch. Note that a PR is only merged into the main branch when all status-checks pass and when it is marked as `done`. 

---

### New rules for pull request base handling:
* Added a rule to comment and notify authors when the base of a pull request is incorrectly set to `main` instead of `canary`.
* Introduced a rule to automatically merge pull requests into `canary` once all status checks pass and the pull request has been reviewed.
* Created a rule to automatically merge changes from `canary` into `main` once all status checks pass and the pull request is marked as done.
* Added a notification rule to inform authors about the missing 'done' label required for merging into `main`.

### Updates to existing rules:
* Updated the rule for auto-assigning reviewers to pull requests to include the `base=canary` condition and corrected the comment messages. [[1]](diffhunk://#diff-6a30e47dd51449847422017b16878889b848f6602ac56d5a2e67ce8a19afade2R84-R90) [[2]](diffhunk://#diff-6a30e47dd51449847422017b16878889b848f6602ac56d5a2e67ce8a19afade2R103-R109)
* Modified the rule for automatic branch updates to trigger when `canary` is ahead instead of `main`.