### PR TITLE
CI: Fixed Auto-Create-PR workflow Latest Tag Retrieval

### DIFF
--- a/.github/workflows/auto-create-pr-canary.yml
+++ b/.github/workflows/auto-create-pr-canary.yml
@@ -32,4 +32,4 @@ jobs:
         with:
           destination_branch: "canary"
           pr_title: "Merge Changes into Main from Canary (${{ steps.previoustag.outputs.tag }}-${{ env.LATEST_HASH }})"
-          pr_draft: true
+          pr_draft: false

--- a/.github/workflows/auto-create-pr-canary.yml
+++ b/.github/workflows/auto-create-pr-canary.yml
@@ -16,11 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Get Latest Tag
-        id: get_version
-        run: |
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null) 
-          echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
+      - name: 'Get Previous tag'
+        id: previoustag
+        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+
 
       - name: Get Latest Hash
         run: |
@@ -32,5 +31,5 @@ jobs:
         uses: repo-sync/pull-request@v2
         with:
           destination_branch: "canary"
-          pr_title: "Merge Changes into Main from Canary (${{ env.LATEST_TAG }}-${{ env.LATEST_HASH }})"
+          pr_title: "Merge Changes into Main from Canary (${{ steps.previoustag.outputs.tag }}-${{ env.LATEST_HASH }})"
           pr_draft: true


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/auto-create-pr-canary.yml` file to improve the process of creating pull requests from the Canary branch to the Main branch. The most important changes focus on using a GitHub action to get the previous tag and modifying the pull request title and draft status accordingly.

### Workflow improvements:

* Replaced the manual script for getting the latest tag with the `WyriHaximus/github-action-get-previous-tag@v1` action.
* Updated the pull request title to use the previous tag output from the new action and set the pull request to be created as a non-draft.