### PR TITLE
CI: Changed Mergify Merge into Main - Merge Method from Rebase to Merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -41,7 +41,7 @@ pull_request_rules:
       comment:
         message: This Pull request satisfies all status-checks and will be automatically merged soon.
       merge:
-        method: rebase
+        method: merge
 
   - name: Notify about Missing Done Label
     description: A Pull Request that is to be merged into the main branch must be marked as done to be merged. Notify authors about missing label, when all checks pass.


### PR DESCRIPTION
This pull request includes a change to the `.mergify.yml` configuration file to adjust the merge method for when PRs are to be merged automatically from canary to main.

### Configuration update:

* [`.mergify.yml`](diffhunk://#diff-6a30e47dd51449847422017b16878889b848f6602ac56d5a2e67ce8a19afade2L44-R44): Changed the merge method from `rebase` to `merge` due to rebase conflicts.