### PR TITLE
Style: Improved ColorMode Handling - Preventing Shifts in the Layout while retrieving ColorMode

### DIFF
--- a/components/root/ColorModeSwitcher.tsx
+++ b/components/root/ColorModeSwitcher.tsx
@@ -15,6 +15,8 @@ export default function ColorModeSwitcher({ defaultValue }: { defaultValue: Colo
 
   return (
     <div className='hover:cursor-pointer' onClick={toggleMode}>
+      {/* Fills the space that is otherwise taken by the Switcher Icon, while no colormode is set  */}
+      <div className={twMerge('size-6', !!mode && 'hidden')} />
       <Transition show={mode === 'light'} enter='transition duration-300' enterFrom='rotate-45 opacity-50' enterTo='rotate-0 opacity-100' leave='hidden'>
         <Icon className={twMerge('size-6', mode === 'dark' && 'hidden')} />
       </Transition>

--- a/components/root/ColorModeSwitcher.tsx
+++ b/components/root/ColorModeSwitcher.tsx
@@ -7,8 +7,10 @@ import { Transition } from '@headlessui/react'
 import useHeroIcon from '@/hooks/useHeroIcon'
 import { twMerge } from 'tailwind-merge'
 
-export default function ColorModeSwitcher() {
-  const { mode, toggleMode } = ColorModeHandler()
+type ColorMode = 'light' | 'dark' | undefined
+
+export default function ColorModeSwitcher({ defaultValue }: { defaultValue: ColorMode } = { defaultValue: undefined }) {
+  const { mode, toggleMode } = ColorModeHandler(defaultValue)
   const Icon = useHeroIcon({ iconName: mode === 'light' ? 'SunIcon' : 'MoonIcon', type: 'solid' })
 
   return (
@@ -24,8 +26,8 @@ export default function ColorModeSwitcher() {
   )
 }
 
-function ColorModeHandler() {
-  const [mode, setMode] = useState<'light' | 'dark' | undefined>()
+function ColorModeHandler(defaultValue: ColorMode) {
+  const [mode, setMode] = useState<ColorMode>(defaultValue)
   const toggleMode = () => setMode(mode === 'light' ? 'dark' : 'light')
 
   useEffect(() => {
@@ -41,7 +43,7 @@ function ColorModeHandler() {
   }, [mode])
 
   useEffect(() => {
-    const userPreference: 'dark' | 'light' = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+    const userPreference: NonNullable<ColorMode> = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
 
     const cookies = parseCookies()
     const colorMode = cookies.colorMode

--- a/components/root/SideBar/variants/DesktopSideBar.tsx
+++ b/components/root/SideBar/variants/DesktopSideBar.tsx
@@ -6,13 +6,16 @@ import { RenderSideBarItems } from '@/components/root/SideBar'
 import { LoadingProfileInformation } from '@/components/root/UserProfile/LoadingUserInformation'
 import UserProfile from '@/components/root/UserProfile/UserProfie'
 import ColorModeSwitcher from '@/components/root/ColorModeSwitcher'
+import getColorMode from '@/lib/getColorMode'
 
-export default function DesktopSideBar(props: SideBarProps) {
+export default async function DesktopSideBar(props: SideBarProps) {
+  const colorMode = await getColorMode()
+
   return (
     <div id='desktop-sidebar-container' className={twMerge('fixed dark:bg-neutral-900/50 bg-gray-200 h-full flex-col p-3 pl-2', DesktopSideBarVisibilityBreakpoints)}>
       <div id={'sidebar-header'} className='flex gap-4 items-center justify-center pb-3 border-b-2 dark:border-neutral-300 border-gray-600'>
         <h3 className='text-xl dark:text-gray-300 text-gray-700'>{props.title}</h3>
-        <ColorModeSwitcher />
+        <ColorModeSwitcher defaultValue={colorMode} />
       </div>
 
       <div className='h-full dark:text-gray-300/90 text-gray-600 py-4'>

--- a/components/root/SideBar/variants/DesktopSideBar.tsx
+++ b/components/root/SideBar/variants/DesktopSideBar.tsx
@@ -8,8 +8,8 @@ import UserProfile from '@/components/root/UserProfile/UserProfie'
 import ColorModeSwitcher from '@/components/root/ColorModeSwitcher'
 import getColorMode from '@/lib/getColorMode'
 
-export default async function DesktopSideBar(props: SideBarProps) {
-  const colorMode = await getColorMode()
+export default function DesktopSideBar(props: SideBarProps) {
+  const colorMode = getColorMode()
 
   return (
     <div id='desktop-sidebar-container' className={twMerge('fixed dark:bg-neutral-900/50 bg-gray-200 h-full flex-col p-3 pl-2', DesktopSideBarVisibilityBreakpoints)}>

--- a/components/root/SideBar/variants/MobileSideBar.tsx
+++ b/components/root/SideBar/variants/MobileSideBar.tsx
@@ -1,18 +1,18 @@
 /* eslint-disable react/jsx-max-depth */
 'use client'
 
-import React, { Fragment, Suspense } from 'react'
+import React, { Suspense } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { MobileSideBarVisibilityBreakpoints } from '@/config/SideBarConfig'
 import { BoltIcon } from '@heroicons/react/24/outline'
 import SideBarProps from '@/typings/root/SideBarProps'
-import { Dialog, Transition } from '@headlessui/react'
 import { RenderSideBarItems } from '@/components/root/SideBar'
 import { LoadingProfileInformation } from '@/components/root/UserProfile/LoadingUserInformation'
 import UserProfile from '@/components/root/UserProfile/UserProfie'
 import ColorModeSwitcher from '@/components/root/ColorModeSwitcher'
-import MobileSideBarContextProvider, { useMobileSideBarContext } from '@/components/root/SideBar/variants/MobileSideBarContext'
+import MobileSideBarContextProvider from '@/components/root/SideBar/variants/MobileSideBarContext'
 import OpenCloseButton from '@/components/root/SideBar/variants/MobileSideBar_OpenCloseButton'
+import MobileSideBarDialog from '@/components/root/SideBar/variants/MobileSideBarDialog'
 
 export default function MobileSideBar(props: SideBarProps) {
   return (
@@ -41,43 +41,5 @@ export default function MobileSideBar(props: SideBarProps) {
         </div>
       </MobileSideBarDialog>
     </MobileSideBarContextProvider>
-  )
-}
-
-/**
- * Renders the dialog that slides in from the left and displays renders the provided children in it
- * @param children The content / children that are rendered in the dialog
- */
-function MobileSideBarDialog({ children }: { children: React.ReactNode }) {
-  const { isOpen, setIsOpen } = useMobileSideBarContext()
-
-  return (
-    <Transition.Root show={isOpen} as={Fragment}>
-      <Dialog as='div' className={twMerge('relative z-50', MobileSideBarVisibilityBreakpoints)} onClose={setIsOpen}>
-        <Transition.Child
-          as={Fragment}
-          enter='transition-opacity ease-linear duration-300'
-          enterFrom='opacity-0'
-          enterTo='opacity-100'
-          leave='transition-opacity ease-linear duration-300'
-          leaveFrom='opacity-100'
-          leaveTo='opacity-0'>
-          <div className='fixed inset-0 bg-neutral-900/80' />
-        </Transition.Child>
-
-        <div className='fixed inset-0 flex'>
-          <Transition.Child
-            as={Fragment}
-            enter='transition ease-in-out duration-300 transform'
-            enterFrom='-translate-x-full'
-            enterTo='translate-x-0'
-            leave='transition ease-in-out duration-300 transform'
-            leaveFrom='translate-x-0'
-            leaveTo='-translate-x-full'>
-            <Dialog.Panel className='relative flex w-full max-w-xs flex-1 sm:max-w-sm'>{children}</Dialog.Panel>
-          </Transition.Child>
-        </div>
-      </Dialog>
-    </Transition.Root>
   )
 }

--- a/components/root/SideBar/variants/MobileSideBar.tsx
+++ b/components/root/SideBar/variants/MobileSideBar.tsx
@@ -10,14 +10,17 @@ import ColorModeSwitcher from '@/components/root/ColorModeSwitcher'
 import MobileSideBarContextProvider from '@/components/root/SideBar/variants/MobileSideBarContext'
 import OpenCloseButton from '@/components/root/SideBar/variants/MobileSideBar_OpenCloseButton'
 import MobileSideBarDialog from '@/components/root/SideBar/variants/MobileSideBarDialog'
+import getColorMode from '@/lib/getColorMode'
 
 export default function MobileSideBar(props: SideBarProps) {
+  const colorMode = getColorMode()
+
   return (
     <MobileSideBarContextProvider>
       <div id='mobile-sidebar-top-bar' className={twMerge('bg-gray-50 dark:bg-neutral-900 p-4 border-b-2 justify-between', MobileSideBarVisibilityBreakpoints)}>
         <OpenCloseButton />
         <h3 className='flex-1 text-center text-lg font-semibold leading-6 text-gray-700 dark:text-gray-200'>{props.title}</h3>
-        <ColorModeSwitcher />
+        <ColorModeSwitcher defaultValue={colorMode} />
       </div>
 
       <MobileSideBarDialog>

--- a/components/root/SideBar/variants/MobileSideBar.tsx
+++ b/components/root/SideBar/variants/MobileSideBar.tsx
@@ -1,6 +1,3 @@
-/* eslint-disable react/jsx-max-depth */
-'use client'
-
 import React, { Suspense } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { MobileSideBarVisibilityBreakpoints } from '@/config/SideBarConfig'

--- a/components/root/SideBar/variants/MobileSideBar.tsx
+++ b/components/root/SideBar/variants/MobileSideBar.tsx
@@ -6,13 +6,13 @@ import { twMerge } from 'tailwind-merge'
 import { MobileSideBarVisibilityBreakpoints } from '@/config/SideBarConfig'
 import { BoltIcon } from '@heroicons/react/24/outline'
 import SideBarProps from '@/typings/root/SideBarProps'
-import useHeroIcon from '@/hooks/useHeroIcon'
 import { Dialog, Transition } from '@headlessui/react'
 import { RenderSideBarItems } from '@/components/root/SideBar'
 import { LoadingProfileInformation } from '@/components/root/UserProfile/LoadingUserInformation'
 import UserProfile from '@/components/root/UserProfile/UserProfie'
 import ColorModeSwitcher from '@/components/root/ColorModeSwitcher'
 import MobileSideBarContextProvider, { useMobileSideBarContext } from '@/components/root/SideBar/variants/MobileSideBarContext'
+import OpenCloseButton from '@/components/root/SideBar/variants/MobileSideBar_OpenCloseButton'
 
 export default function MobileSideBar(props: SideBarProps) {
   return (
@@ -41,23 +41,6 @@ export default function MobileSideBar(props: SideBarProps) {
         </div>
       </MobileSideBarDialog>
     </MobileSideBarContextProvider>
-  )
-}
-
-/**
- * This component renders a button that opens or closes the mobile sidebar depending on its open-state.
- */
-function OpenCloseButton() {
-  const { isOpen, setIsOpen } = useMobileSideBarContext()
-  const screenReaderText = isOpen ? 'Close sidebar' : 'Open sidebar'
-  const ButtonIcon = useHeroIcon({ iconName: isOpen ? 'XMarkIcon' : 'Bars3Icon' })
-
-  return (
-    <button name='open-close-button' type='button' className='-m-2.5 p-2.5 text-gray-700 dark:text-gray-200' onClick={() => setIsOpen(!isOpen)}>
-      <span className='sr-only'>{screenReaderText}</span>
-
-      <ButtonIcon className='size-6' />
-    </button>
   )
 }
 

--- a/components/root/SideBar/variants/MobileSideBar.tsx
+++ b/components/root/SideBar/variants/MobileSideBar.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-max-depth */
 'use client'
 
-import React, { createContext, Fragment, Suspense, useContext, useState } from 'react'
+import React, { Fragment, Suspense } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { MobileSideBarVisibilityBreakpoints } from '@/config/SideBarConfig'
 import { BoltIcon } from '@heroicons/react/24/outline'
@@ -12,25 +12,11 @@ import { RenderSideBarItems } from '@/components/root/SideBar'
 import { LoadingProfileInformation } from '@/components/root/UserProfile/LoadingUserInformation'
 import UserProfile from '@/components/root/UserProfile/UserProfie'
 import ColorModeSwitcher from '@/components/root/ColorModeSwitcher'
-
-interface MobileSideBarContextProps {
-  isOpen: boolean
-  setIsOpen: (value: boolean) => void
-}
-
-const MobileSideBarContext = createContext<MobileSideBarContextProps>({} as MobileSideBarContextProps)
-
-function useMobileSideBarContext() {
-  const context = useContext(MobileSideBarContext)
-
-  return context
-}
+import MobileSideBarContextProvider, { useMobileSideBarContext } from '@/components/root/SideBar/variants/MobileSideBarContext'
 
 export default function MobileSideBar(props: SideBarProps) {
-  const [isOpen, setIsOpen] = useState(false)
-
   return (
-    <MobileSideBarContext.Provider value={{ isOpen, setIsOpen }}>
+    <MobileSideBarContextProvider>
       <div id='mobile-sidebar-top-bar' className={twMerge('bg-gray-50 dark:bg-neutral-900 p-4 border-b-2 justify-between', MobileSideBarVisibilityBreakpoints)}>
         <OpenCloseButton />
         <h3 className='flex-1 text-center text-lg font-semibold leading-6 text-gray-700 dark:text-gray-200'>{props.title}</h3>
@@ -54,7 +40,7 @@ export default function MobileSideBar(props: SideBarProps) {
           </Suspense>
         </div>
       </MobileSideBarDialog>
-    </MobileSideBarContext.Provider>
+    </MobileSideBarContextProvider>
   )
 }
 

--- a/components/root/SideBar/variants/MobileSideBarContext.tsx
+++ b/components/root/SideBar/variants/MobileSideBarContext.tsx
@@ -1,0 +1,24 @@
+import { createContext, useContext, useState } from 'react'
+
+interface MobileSideBarContextProps {
+  isOpen: boolean
+  setIsOpen: (value: boolean) => void
+}
+
+const MobileSideBarContext = createContext<MobileSideBarContextProps>({} as MobileSideBarContextProps)
+
+export function useMobileSideBarContext() {
+  const context = useContext(MobileSideBarContext)
+
+  if (!context) {
+    throw new Error('useMobileSideBarContext must be used within a MobileSideBarContextProvider')
+  }
+
+  return context
+}
+
+export default function MobileSideBarContextProvider({ children }: { children: React.ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return <MobileSideBarContext.Provider value={{ isOpen, setIsOpen }}>{children}</MobileSideBarContext.Provider>
+}

--- a/components/root/SideBar/variants/MobileSideBarContext.tsx
+++ b/components/root/SideBar/variants/MobileSideBarContext.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { createContext, useContext, useState } from 'react'
 
 interface MobileSideBarContextProps {

--- a/components/root/SideBar/variants/MobileSideBarDialog.tsx
+++ b/components/root/SideBar/variants/MobileSideBarDialog.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import React, { Fragment } from 'react'
+import { useMobileSideBarContext } from '@/components/root/SideBar/variants/MobileSideBarContext'
+import { Dialog, Transition } from '@headlessui/react'
+import { twMerge } from 'tailwind-merge'
+import { MobileSideBarVisibilityBreakpoints } from '@/config/SideBarConfig'
+
+/**
+ * Renders the dialog that slides in from the left and displays renders the provided children in it
+ * @param children The content / children that are rendered in the dialog
+ */
+export default function MobileSideBarDialog({ children }: { children: React.ReactNode }) {
+  const { isOpen, setIsOpen } = useMobileSideBarContext()
+
+  return (
+    <Transition.Root show={isOpen} as={Fragment}>
+      <Dialog as='div' className={twMerge('relative z-50', MobileSideBarVisibilityBreakpoints)} onClose={setIsOpen}>
+        <Transition.Child
+          as={Fragment}
+          enter='transition-opacity ease-linear duration-300'
+          enterFrom='opacity-0'
+          enterTo='opacity-100'
+          leave='transition-opacity ease-linear duration-300'
+          leaveFrom='opacity-100'
+          leaveTo='opacity-0'>
+          <div className='fixed inset-0 bg-neutral-900/80' />
+        </Transition.Child>
+
+        <div className='fixed inset-0 flex'>
+          <Transition.Child
+            as={Fragment}
+            enter='transition ease-in-out duration-300 transform'
+            enterFrom='-translate-x-full'
+            enterTo='translate-x-0'
+            leave='transition ease-in-out duration-300 transform'
+            leaveFrom='translate-x-0'
+            leaveTo='-translate-x-full'>
+            <Dialog.Panel className='relative flex w-full max-w-xs flex-1 sm:max-w-sm'>{children}</Dialog.Panel>
+          </Transition.Child>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  )
+}

--- a/components/root/SideBar/variants/MobileSideBar_OpenCloseButton.tsx
+++ b/components/root/SideBar/variants/MobileSideBar_OpenCloseButton.tsx
@@ -1,0 +1,19 @@
+import { useMobileSideBarContext } from '@/components/root/SideBar/variants/MobileSideBarContext'
+import useHeroIcon from '@/hooks/useHeroIcon'
+
+/**
+ * This component renders a button that opens or closes the mobile sidebar depending on its open-state.
+ */
+export default function MobileSideBar_OpenCloseButton() {
+  const { isOpen, setIsOpen } = useMobileSideBarContext()
+  const screenReaderText = isOpen ? 'Close sidebar' : 'Open sidebar'
+  const ButtonIcon = useHeroIcon({ iconName: isOpen ? 'XMarkIcon' : 'Bars3Icon' })
+
+  return (
+    <button name='open-close-button' type='button' className='-m-2.5 p-2.5 text-gray-700 dark:text-gray-200' onClick={() => setIsOpen(!isOpen)}>
+      <span className='sr-only'>{screenReaderText}</span>
+
+      <ButtonIcon className='size-6' />
+    </button>
+  )
+}

--- a/components/root/SideBar/variants/MobileSideBar_OpenCloseButton.tsx
+++ b/components/root/SideBar/variants/MobileSideBar_OpenCloseButton.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { useMobileSideBarContext } from '@/components/root/SideBar/variants/MobileSideBarContext'
 import useHeroIcon from '@/hooks/useHeroIcon'
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,6 +12,7 @@ const config: Config = {
   testMatch: ['<rootDir>/tests/jest/**/*.test.tsx', '<rootDir>/tests/jest/**/*.test.ts'],
   coverageProvider: 'v8',
   testEnvironment: 'jsdom',
+  maxWorkers: '50%',
   // Add more setup options before each test is run
   setupFilesAfterEnv: ['./jest.setup.ts'],
   moduleNameMapper: {

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -21,3 +21,9 @@ jest.mock('./components/root/ColorModeSwitcher', () => ({
   __esModule: true, // Indicates that the module uses ES modules
   default: jest.fn(), // Mock the default export as a Jest mock function
 }))
+
+//? Mocking the getColorMode function because the `cookies` property is not available in the jest test environment.
+jest.mock('@/lib/getColorMode', () => ({
+  __esModule: true, // Indicates that the module uses ES modules
+  default: jest.fn(), // Mock the default export as a Jest mock function
+}))

--- a/lib/getColorMode.ts
+++ b/lib/getColorMode.ts
@@ -1,8 +1,10 @@
 import { cookies as nextCookies } from 'next/dist/client/components/headers'
 
-export default function getColorMode(): 'light' | 'dark' {
+export default function getColorMode(): 'light' | 'dark' | undefined {
   const cookies = nextCookies()
   const colorMode = cookies.get('colorMode' as never)?.value
+
+  if (!colorMode) return undefined
 
   return colorMode === 'light' ? 'light' : 'dark'
 }

--- a/tests/playwright/root/page.test.ts
+++ b/tests/playwright/root/page.test.ts
@@ -49,7 +49,7 @@ test('Root Page shows animation', async ({ page }) => {
 test.use({ colorScheme: 'dark' })
 test('Check that Color Mode can be switched', async ({ page }) => {
   await page.goto('http://localhost:3000/')
-  const colorModeSwitcher = page.locator('#sidebar-header div')
+  const colorModeSwitcher = page.locator('#sidebar-header > div')
   await expect(colorModeSwitcher).toBeVisible()
 
   const html = page.locator('html')


### PR DESCRIPTION
This pull request includes several changes to the `ColorModeSwitcher` component and the `MobileSideBar` component. The primary focus is on improving the visual appearance when the page loads. Thereby improving the handling of color modes and refactoring the mobile sidebar context and related components.

These changes transformed the `MobileSideBar` component from being a client component to a server component, which makes it possible to access the color-mode on the server-side through cookies.

### Enhancements to `ColorModeSwitcher`:

* [`components/root/ColorModeSwitcher.tsx`](diffhunk://#diff-8f21e3190ed5d3f175c010f24f6269a2ad2f0e22cabc78349271811b5bb72b4cL10-R19): Introduced a `defaultValue` prop to the `ColorModeSwitcher` to allow setting a default color mode. Updated `ColorModeHandler` to use this default value. [[1]](diffhunk://#diff-8f21e3190ed5d3f175c010f24f6269a2ad2f0e22cabc78349271811b5bb72b4cL10-R19) [[2]](diffhunk://#diff-8f21e3190ed5d3f175c010f24f6269a2ad2f0e22cabc78349271811b5bb72b4cL27-R32) [[3]](diffhunk://#diff-8f21e3190ed5d3f175c010f24f6269a2ad2f0e22cabc78349271811b5bb72b4cL44-R48)

### Refactoring `MobileSideBar`:

* [`components/root/SideBar/variants/MobileSideBar.tsx`](diffhunk://#diff-e0f29134d15c926eab554a71a7cfc3f4b42a397bf67dc88c0713ab000936d9ccL1-R23): Removed the internal context and moved it to a separate file. Updated the component to use `MobileSideBarContextProvider` and imported new components for better modularity. [[1]](diffhunk://#diff-e0f29134d15c926eab554a71a7cfc3f4b42a397bf67dc88c0713ab000936d9ccL1-R23) [[2]](diffhunk://#diff-e0f29134d15c926eab554a71a7cfc3f4b42a397bf67dc88c0713ab000936d9ccL57-R43)
* [`components/root/SideBar/variants/MobileSideBarContext.tsx`](diffhunk://#diff-206a2a0ad5e241a2622bbf8f9c8a58476b9d807def4eb0b315c4f93534ed4926R1-R25): Created a new context provider for the mobile sidebar state management.
* [`components/root/SideBar/variants/MobileSideBarDialog.tsx`](diffhunk://#diff-b8104598ef77d099861b8cea10b771d61f27bcfb4bd7bb4deaeba2017efaa06eR1-R45): Moved the dialog rendering logic to a separate component.
* [`components/root/SideBar/variants/MobileSideBar_OpenCloseButton.tsx`](diffhunk://#diff-a5c2212fda884cb35433bde906c70af28dbc6fd053a2b10b9fc23ffb17cae325R1-R20): Moved the open/close button logic to a separate component.

### Additional Changes:

* [`lib/getColorMode.ts`](diffhunk://#diff-847b5499682b16f3c380c09afda81816a19c4b32fc970fea46c1af2dc0c49c35L3-R8): Updated the `getColorMode` function to return `undefined` if no color mode is set.
* [`jest.setup.ts`](diffhunk://#diff-a1c786cdea90125d840669112d499d337a658bf6431a8c972a2e14301d908662R24-R29): Added a mock for the `getColorMode` function to handle the absence of the `cookies` property in the Jest test environment.
* [`tests/playwright/root/page.test.ts`](diffhunk://#diff-38da8c486f8e478fdd09bc477adb5f34c73c38ee68a582d9c17ed2ee49015be0L52-R52): Adjusted the selector for the color mode switcher in the Playwright test.