### PR TITLE
Feat: Implementation of Auto-Close Logic of MobileSideBar

### DIFF
--- a/components/root/SideBar/variants/MobileSideBar_OpenCloseButton.tsx
+++ b/components/root/SideBar/variants/MobileSideBar_OpenCloseButton.tsx
@@ -1,14 +1,27 @@
 'use client'
 import { useMobileSideBarContext } from '@/components/root/SideBar/variants/MobileSideBarContext'
 import useHeroIcon from '@/hooks/useHeroIcon'
+import { useEffect, useState } from 'react'
+import { usePathname } from 'next/navigation'
 
 /**
  * This component renders a button that opens or closes the mobile sidebar depending on its open-state.
  */
 export default function MobileSideBar_OpenCloseButton() {
   const { isOpen, setIsOpen } = useMobileSideBarContext()
+  const pathname = usePathname()
+  const [cachedPathname, setCachedPathname] = useState(pathname)
   const screenReaderText = isOpen ? 'Close sidebar' : 'Open sidebar'
   const ButtonIcon = useHeroIcon({ iconName: isOpen ? 'XMarkIcon' : 'Bars3Icon' })
+
+  //? Auto-Close Navigation Bar when route-changes => navigation-item was clicked
+  useEffect(() => {
+    if (cachedPathname === pathname) return
+    if (!isOpen) return
+
+    setIsOpen(false)
+    setCachedPathname(pathname)
+  }, [pathname])
 
   return (
     <button name='open-close-button' type='button' className='-m-2.5 p-2.5 text-gray-700 dark:text-gray-200' onClick={() => setIsOpen(!isOpen)}>


### PR DESCRIPTION
This pull request introduces enhancements to the `MobileSideBar` component to improve its behavior when navigating between routes. The main change involves automatically closing the sidebar when a navigation item is clicked or more specifically when the route changes. This means that when the same item is clicked, the mobile sidebar remains open.

### Key changes include:

* [`components/root/SideBar/variants/MobileSideBar_OpenCloseButton.tsx`](diffhunk://#diff-a5c2212fda884cb35433bde906c70af28dbc6fd053a2b10b9fc23ffb17cae325R4-R25): Added `useEffect` and `useState` hooks to automatically close it when the route changes.