### PR TITLE
CI: Semantic Versioning of Docker Images 

### DIFF
--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   build-and-push-docker-image:
     runs-on: ubuntu-latest
+    needs: semantic-versioning
+
     env:
       REPO_NAME: ${{ github.repository }}
       NEXT_AUTH_GITHUB_ID: ${{ secrets.NEXT_AUTH_GITHUB_ID }}

--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -59,3 +59,5 @@ jobs:
 
       - name: Push the tagged image
         run: docker push ghcr.io/${{ env.LOWER_REPO_NAME }}:${{ steps.previoustag.outputs.tag }}
+        continue-on-error: true
+        

--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -50,12 +50,3 @@ jobs:
 
       - name: Set lowercase package name as environment variable
         run: echo "LOWER_PACKAGE_NAME=$(echo ${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
-
-      - name: Delete old docker-image package versions
-        uses: actions/delete-package-versions@v5
-        with:
-          package-name: ${{ env.LOWER_PACKAGE_NAME }}
-          owner: 'kilowatt-commando'
-          package-type: 'container'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          min-versions-to-keep: 2

--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2

--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -42,11 +42,18 @@ jobs:
           echo "NEXTAUTH_URL=${{ env.NEXTAUTH_URL }}" >> .env
           echo "NEXTAUTH_SECRET=${{ env.NEXTAUTH_SECRET }}" >> .env
 
+      - name: 'Get Previous tag'
+        id: previoustag
+        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+
       - name: Build the Docker image
         run: docker build -t ghcr.io/${{ env.LOWER_REPO_NAME }}:latest .
 
       - name: Push the image
         run: docker push ghcr.io/${{ env.LOWER_REPO_NAME }}:latest
 
-      - name: Set lowercase package name as environment variable
-        run: echo "LOWER_PACKAGE_NAME=$(echo ${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+      - name: Tag Image based on current tag
+        run: docker tag ghcr.io/${{ env.LOWER_REPO_NAME }}:latest ghcr.io/${{ env.LOWER_REPO_NAME }}:${{ steps.previoustag.outputs.tag }}
+
+      - name: Push the tagged image
+        run: docker push ghcr.io/${{ env.LOWER_REPO_NAME }}:${{ steps.previoustag.outputs.tag }}

--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -43,6 +43,8 @@ jobs:
           echo "NEXT_AUTH_GITHUB_SECRET=${{ env.NEXT_AUTH_GITHUB_SECRET }}" >> .env
           echo "NEXTAUTH_URL=${{ env.NEXTAUTH_URL }}" >> .env
           echo "NEXTAUTH_SECRET=${{ env.NEXTAUTH_SECRET }}" >> .env
+          echo "DATA_API=${{ env.DATA_API }}" >> .env
+          echo "CONTROL_API=${{ env.CONTROL_API }}" >> .env
 
       - name: 'Get Previous tag'
         id: previoustag
@@ -60,4 +62,3 @@ jobs:
       - name: Push the tagged image
         run: docker push ghcr.io/${{ env.LOWER_REPO_NAME }}:${{ steps.previoustag.outputs.tag }}
         continue-on-error: true
-        


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/build-push-docker-image.yml` file to enhance the Docker image build and push process. The most important changes include adding a dependency on the `semantic-versioning` job, retrieving the previous tag, and tagging the Docker image based on the current tag, while still pushing the docker-image with the latest tag.

### Enhancements to Docker image build and push process:

* Added a dependency on the `semantic-versioning` job to ensure proper versioning before building and pushing the Docker image. (`.github/workflows/build-push-docker-image.yml`)
* Introduced a step to retrieve the previous tag using the `WyriHaximus/github-action-get-previous-tag@v1` action. (`.github/workflows/build-push-docker-image.yml`)
* Updated the process to tag the Docker image based on the current tag and push the tagged image to the repository. (`.github/workflows/build-push-docker-image.yml`)