### PR TITLE
CI: Resolved Latest Tag and Commit Hash Issues in Auto-Create-PR-Canary Workflow

### DIFF
--- a/.github/workflows/auto-create-pr-canary.yml
+++ b/.github/workflows/auto-create-pr-canary.yml
@@ -65,4 +65,5 @@ jobs:
         with:
           destination_branch: "main"
           pr_title: "Merge Changes into Main from Canary (${{ steps.latest_release_tag.outputs.tag }}-${{ steps.commit_main.outputs.commit_hash }})"
+          pr_body: "This PR was automatically created by the Auto-Create-PR-Canary workflow to merge changes from the canary branch into main. These changes are based on ${{ steps.latest_release_tag.outputs.tag }} and the latest commit on main (${{ steps.commit_main.outputs.commit_hash }})."
           pr_draft: false

--- a/.github/workflows/auto-create-pr-canary.yml
+++ b/.github/workflows/auto-create-pr-canary.yml
@@ -46,16 +46,23 @@ jobs:
         run: |
           echo "The latest non-prerelease tag is: ${{ steps.latest_release_tag.outputs.tag }}"
 
-
-      - name: Get Latest Hash
+      - name: Get latest commit hash on main
+        id: commit_main
         run: |
-            LATEST_HASH=$(git rev-parse --short HEAD)
-            echo "LATEST_HASH=$LATEST_HASH" >> $GITHUB_ENV
+          # Make sure we have the latest info for 'main' from origin
+          git fetch origin main
+          COMMIT_HASH=$(git rev-parse --short origin/main)
+          echo "commit_hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
+
+      - name: Display results
+        run: |
+          echo "Latest release tag (ignoring pre-releases): ${{ steps.latest_release_tag.outputs.tag }}"
+          echo "Latest commit hash on main:               ${{ steps.commit_main.outputs.commit_hash }}"
 
       - name: Create pull request
         id: open-pr
         uses: repo-sync/pull-request@v2
         with:
           destination_branch: "main"
-          pr_title: "Merge Changes into Main from Canary (${{ steps.latest_release_tag.outputs.tag }}-${{ env.LATEST_HASH }})"
+          pr_title: "Merge Changes into Main from Canary (${{ steps.latest_release_tag.outputs.tag }}-${{ steps.commit_main.outputs.commit_hash }})"
           pr_draft: false

--- a/.github/workflows/auto-create-pr-canary.yml
+++ b/.github/workflows/auto-create-pr-canary.yml
@@ -14,10 +14,37 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-      - name: 'Get Previous tag'
-        id: previoustag
-        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+      - name: Fetch all tags
+        run: git fetch --tags --force
+
+      - name: Get latest non-prerelease tag
+        id: latest_release_tag
+        run: |
+          # 1. Get all tags starting with v, e.g., "v1.2.3", "v1.2.0-canary1"
+          # 2. Filter out those with a '-' (which typically indicates pre-release or metadata)
+          # 3. Sort them semver descending
+          # 4. Pick the first one
+          
+          TAGS=$(git tag --list "v*" | grep -v "-")
+          if [ -z "$TAGS" ]; then
+            echo "No non-prerelease tags found."
+            echo "tag=" >> $GITHUB_OUTPUT
+          else
+            # Sort tags in version order descending, then grab the first
+            LATEST_TAG=$(echo "$TAGS" | sort -V | tail -n1)
+          
+            echo "Found the following release tags:"
+            echo "$TAGS"
+            echo "Latest release tag is: $LATEST_TAG"
+            echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Print the tag
+        run: |
+          echo "The latest non-prerelease tag is: ${{ steps.latest_release_tag.outputs.tag }}"
 
 
       - name: Get Latest Hash
@@ -30,5 +57,5 @@ jobs:
         uses: repo-sync/pull-request@v2
         with:
           destination_branch: "main"
-          pr_title: "Merge Changes into Main from Canary (${{ steps.previoustag.outputs.tag }}-${{ env.LATEST_HASH }})"
+          pr_title: "Merge Changes into Main from Canary (${{ steps.latest_release_tag.outputs.tag }}-${{ env.LATEST_HASH }})"
           pr_draft: false


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow file `.github/workflows/auto-create-pr-canary.yml` to improve the process of creating pull requests from the canary branch to the main branch. The most important changes involve fetching all tags, identifying the latest non-prerelease tag, and obtaining the latest commit hash on the main branch.

### Improvements to the workflow:

* [`.github/workflows/auto-create-pr-canary.yml`](diffhunk://#diff-f34442add906ce5761754bcde69704cb157b70817a0490e3677c851659d53819R17-R68): Added steps to fetch all tags and get the latest non-prerelease tag.
* [`.github/workflows/auto-create-pr-canary.yml`](diffhunk://#diff-f34442add906ce5761754bcde69704cb157b70817a0490e3677c851659d53819R17-R68): Added a step to fetch the latest commit hash on the main branch.
* [`.github/workflows/auto-create-pr-canary.yml`](diffhunk://#diff-f34442add906ce5761754bcde69704cb157b70817a0490e3677c851659d53819R17-R68): Updated the pull request title and body to include the latest non-prerelease tag and the latest commit hash on the main branch.