### PR TITLE
Fix: Resolved Docker Build Image Workflow Error

### DIFF
--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -10,6 +10,13 @@ permissions:
   packages: write
 
 jobs:
+  wait-for-semantic-versioning:
+    # This way we ensure that each workflow has at least one job without dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Just exit
+        run: echo "Doing nothing..."
+
   build-and-push-docker-image:
     runs-on: ubuntu-latest
     needs: semantic-versioning


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/build-push-docker-image.yml` file. The change adds a new job to the workflow to ensure that each workflow has at least one job without dependencies.

Workflow modification:

* [`.github/workflows/build-push-docker-image.yml`](diffhunk://#diff-16a6973e9a12990dc9265a3cf2ce7a82225ed139a55e85fb6e86e6d131afe127R13-R19): Added a `wait-for-semantic-versioning` job that runs on `ubuntu-latest` and executes a simple step to ensure no dependencies for at least one job in the workflow.