### PR TITLE
CI: Resolved Canary Branch being Behind by Adding Mergify Auto-Update Rule

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -129,4 +129,13 @@ pull_request_rules:
       comment:
         message: "@{{ author }} This Pull request has been automatically updated, because the canary branch was ahead."
 
+  - name: Automatic Update-Branch when Main is ahead
+    conditions:
+      - base = main
+      - "#commits-behind > 0"
+    actions:
+      update:
+      comment:
+        message: "This Pull request has been automatically updated, because the main branch was ahead."
+
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -132,6 +132,7 @@ pull_request_rules:
   - name: Automatic Update-Branch when Main is ahead
     conditions:
       - base = main
+      - head=canary
       - "#commits-behind > 0"
     actions:
       update:


### PR DESCRIPTION
This pull request includes a change to the `.mergify.yml` file to add a new rule for automatically update the canary branch when the main branch is ahead.

### Improvements to the automatic branch update process:

* [`.mergify.yml`](diffhunk://#diff-6a30e47dd51449847422017b16878889b848f6602ac56d5a2e67ce8a19afade2R132-R140): Added a new rule named "Automatic Update-Branch when Main is ahead" that triggers an update action and posts a comment if the base branch is `main` and the pull request is behind the main branch.