### PR TITLE
CI: Update Auto-Review Trigger Event

### DIFF
--- a/.github/workflows/auto-review-workflow.yml
+++ b/.github/workflows/auto-review-workflow.yml
@@ -1,6 +1,10 @@
 name: Auto PR Review
 
-on: [pull_request]
+on:
+  push:
+    branches-ignore:
+      - main
+      - canary
 
 jobs:
   auto-review:


### PR DESCRIPTION
This pull request modifies the `.github/workflows/auto-review-workflow.yml` file to adjust the triggering conditions for the auto PR review workflow.

### Changes to workflow triggering conditions:

* [`.github/workflows/auto-review-workflow.yml`](diffhunk://#diff-bbbd72706bff94c5295a755639f4bfca7267e17f650083daafc00f46a31072d7L3-R7): Changed the event that triggers the workflow from `pull_request` to `push`, and added a condition to ignore pushes to the `main` and `canary` branches.