### PR TITLE
CI: Fix Docker Image Build Workflow to properly depend on Semantic-Versioning

### DIFF
--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -9,13 +9,28 @@ permissions:
   contents: read
   packages: write
 
+env:
+  GH_TOKEN: ${{ secrets.ACCESS_TOKEN_SEMANTIC_VERSIONING }}
+
 jobs:
-  wait-for-semantic-versioning:
-    # This way we ensure that each workflow has at least one job without dependencies
+  semantic-versioning:
     runs-on: ubuntu-latest
+
     steps:
-      - name: Just exit
-        run: echo "Doing nothing..."
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Node 21
+        uses: actions/setup-node@v3
+        with:
+          node-version: 21
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Run semantice release
+        run: |
+          npm run semantic-release
 
   build-and-push-docker-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -1,4 +1,4 @@
-name: Build and Push Docker Image
+name: Semantic Versioning and Docker Image Build, Push on Main Branch
 
 on:
   push:

--- a/.github/workflows/semantic-versioning.yml
+++ b/.github/workflows/semantic-versioning.yml
@@ -1,9 +1,8 @@
-name: Automatic Semantic Versioning
+name: Automatic Semantic Versioning for Canary Branch
 
 on:
   push:
     branches:
-      - main
       - canary
   workflow_dispatch:
 


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows to support the semantic versioning of docker images. The most important changes include copying the semantic-versioning job into the docker-build workflow file and adjusting branch triggers of both workflows.

### Enhancements to semantic versioning and Docker image workflows:

* [`.github/workflows/build-push-docker-image.yml`](diffhunk://#diff-16a6973e9a12990dc9265a3cf2ce7a82225ed139a55e85fb6e86e6d131afe127L1-R1): Renamed the workflow to "Semantic Versioning and Docker Image Build, Push on Main Branch" and added a new job for semantic versioning, which is needed so that the docker-build job can depend on it. [[1]](diffhunk://#diff-16a6973e9a12990dc9265a3cf2ce7a82225ed139a55e85fb6e86e6d131afe127L1-R1) [[2]](diffhunk://#diff-16a6973e9a12990dc9265a3cf2ce7a82225ed139a55e85fb6e86e6d131afe127R12-R33)
* [`.github/workflows/semantic-versioning.yml`](diffhunk://#diff-2e03ee4e8990e529eb053f6703dba8e81e9f64be6d488bee5948c8e96b633b77L1-L6): Renamed the workflow to "Automatic Semantic Versioning for Canary Branch" and adjusted the trigger to only include the `canary` branch.