### PR TITLE
CI: Fix Semantic Versioning Permissions in Docker Image Build Workflow

### DIFF
--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 env:


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/build-push-docker-image.yml` file to modify permissions for the GitHub Actions workflow. The most important change is:

* [`.github/workflows/build-push-docker-image.yml`](diffhunk://#diff-16a6973e9a12990dc9265a3cf2ce7a82225ed139a55e85fb6e86e6d131afe127L9-R9): Changed the `contents` permission from `read` to `write` to allow the workflow to make changes to the repository contents.